### PR TITLE
fix: workflows now properly use private packages

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,4 +7,7 @@ on:
 jobs:
   automerge:
     uses: llmzy/github-workflows/.github/workflows/automerge.yml@main
+    with:
+      registryUrl: 'https://npm.pkg.github.com'
+      scope: '@llmzy'
     secrets: inherit

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -35,4 +35,6 @@ jobs:
     with:
       tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
+      publishToGithubPackages: true
+      scope: '@llmzy'
     secrets: inherit


### PR DESCRIPTION
Workflows were failing because we couldn't install @llmzy/release-management. This required changes to the reusable @llmzy/github-workflows and to the workflows in this project which call them.